### PR TITLE
Using IPI sometime workers are starting before they can get the IP and fails

### DIFF
--- a/tasks/base_virt_ipi.yml
+++ b/tasks/base_virt_ipi.yml
@@ -252,7 +252,7 @@
     --network network:ocp4-provisioning,mac={{ item.value.prov_network }}
     --network network:ocp4-net,mac={{ item.value.base_network }}
     --network network:ocp4-net,mac={{ item.value.ext_network }}
-    --boot hd,network --noautoconsole --vnc --name ocp4-{{ item.key }} --noreboot
+    --boot hd,network --noautoconsole --vnc --name ocp4-{{ item.key }} --boot bios.rebootTimeout=0
   with_dict: "{{ vms['workers'] }}"
   when:
     - not ocp4_aio_deploy_ocp_plus
@@ -272,7 +272,7 @@
     --network network:ocp4-provisioning,mac={{ item.value.prov_network }}
     --network network:ocp4-net,mac={{ item.value.base_network }}
     --network network:ocp4-net,mac={{ item.value.ext_network }}
-    --boot hd,network --noautoconsole --vnc --name ocp4-{{ item.key }} --noreboot
+    --boot hd,network --noautoconsole --vnc --name ocp4-{{ item.key }} --boot bios.rebootTimeout=0
   with_dict: "{{ vms['workers_opp'] }}"
   when:
     - ocp4_aio_deploy_ocp_plus or ocp4_aio_deploy_big_vms


### PR DESCRIPTION
With this change, the VM will reboot always till can boot from pxe or disk