### PR TITLE
Centos download rescueblock

### DIFF
--- a/tasks/base_virt_ipi.yml
+++ b/tasks/base_virt_ipi.yml
@@ -120,11 +120,26 @@
   register: base_result
 
 - name: Downloading CentOS 8 base image
-  ansible.builtin.get_url:
-    url: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20220913.0.x86_64.qcow2
-    dest: /var/lib/libvirt/images/centos8-kvm.qcow2
-    mode: 0644
-  when: not base_result.stat.exists
+  block:
+    - name: Downloading CentOS 8 base image - primary site
+      ansible.builtin.get_url:
+        url: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20230308.3.x86_64.qcow2
+        dest: /var/lib/libvirt/images/centos8-kvm.qcow2
+        checksum: sha256:1ab4a628211a9178979e916f9dc59c8db67b203666aab15743ea80e17f7d408
+        mode: 0644
+      when: not base_result.stat.exists
+  rescue:
+    - name: Remove broken file (delete file)
+      ansible.builtin.file:
+      path: /var/lib/libvirt/images/centos8-kvm.qcow2
+      state: absent
+    - name: Downloading CentOS 8 base image - rescue site
+      ansible.builtin.get_url:
+        url: https://rhdp-images.s3.amazonaws.com/CentOS-Stream-GenericCloud-8.x86_64.qcow2
+        dest: /var/lib/libvirt/images/centos8-kvm.qcow2
+        checksum: sha256:1ab4a628211a9178979e916f9dc59c8db67b203666aab15743ea80e17f7d408
+        mode: 0644
+      when: not base_result.stat.exists
 
 - name: Copy over ifcfg-eth0 for bastion VM
   ansible.builtin.copy:

--- a/tasks/base_virt_sno.yml
+++ b/tasks/base_virt_sno.yml
@@ -62,13 +62,6 @@
         mode: 0644
       when: not base_result.stat.exists
 
-- name: Downloading CentOS 8 base image
-  ansible.builtin.get_url:
-    url: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20220913.0.x86_64.qcow2
-    dest: /var/lib/libvirt/images/centos8-kvm.qcow2
-    mode: 0644
-  when: not base_result.stat.exists
-
 - name: Copy over ifcfg-eth0 for bastion VM
   ansible.builtin.copy:
     src: "ifcfg-eth0"

--- a/tasks/base_virt_sno.yml
+++ b/tasks/base_virt_sno.yml
@@ -41,6 +41,28 @@
   register: base_result
 
 - name: Downloading CentOS 8 base image
+  block:
+    - name: Downloading CentOS 8 base image - primary site
+      ansible.builtin.get_url:
+        url: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20230308.3.x86_64.qcow2
+        dest: /var/lib/libvirt/images/centos8-kvm.qcow2
+        checksum: sha256:1ab4a628211a9178979e916f9dc59c8db67b203666aab15743ea80e17f7d408
+        mode: 0644
+      when: not base_result.stat.exists
+  rescue:
+    - name: Remove broken file (delete file)
+      ansible.builtin.file:
+      path: /var/lib/libvirt/images/centos8-kvm.qcow2
+      state: absent
+    - name: Downloading CentOS 8 base image - rescue site
+      ansible.builtin.get_url:
+        url: https://rhdp-images.s3.amazonaws.com/CentOS-Stream-GenericCloud-8.x86_64.qcow2
+        dest: /var/lib/libvirt/images/centos8-kvm.qcow2
+        checksum: sha256:1ab4a628211a9178979e916f9dc59c8db67b203666aab15743ea80e17f7d408
+        mode: 0644
+      when: not base_result.stat.exists
+
+- name: Downloading CentOS 8 base image
   ansible.builtin.get_url:
     url: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20220913.0.x86_64.qcow2
     dest: /var/lib/libvirt/images/centos8-kvm.qcow2


### PR DESCRIPTION
Creating rescue block for CentOS image download failure from primary, and updating CentOS primary download link to extant image 