### PR TITLE
Update base_virt_ipi.yml - fix syntax

### DIFF
--- a/tasks/base_virt_ipi.yml
+++ b/tasks/base_virt_ipi.yml
@@ -131,8 +131,8 @@
   rescue:
     - name: Remove broken file (delete file)
       ansible.builtin.file:
-      path: /var/lib/libvirt/images/centos8-kvm.qcow2
-      state: absent
+        path: /var/lib/libvirt/images/centos8-kvm.qcow2
+        state: absent
     - name: Downloading CentOS 8 base image - rescue site
       ansible.builtin.get_url:
         url: https://rhdp-images.s3.amazonaws.com/CentOS-Stream-GenericCloud-8.x86_64.qcow2


### PR DESCRIPTION
TASK [Setup base virt] ********************************************************* ERROR! conflicting action statements: ansible.builtin.file, path The error appears to be in '/runner/project/ansible/configs/ocp4-equinix-aio/roles/ocp4_aio_base_virt/tasks/base_virt_ipi.yml': line 132, column 7, but may be elsewhere in the file depending on the exact syntax problem. The offending line appears to be:
  rescue:
    - name: Remove broken file (delete file) ^ here